### PR TITLE
Perfdata and Cell History DataFrame names editable

### DIFF
--- a/jumper_extension/core/parsers.py
+++ b/jumper_extension/core/parsers.py
@@ -55,6 +55,7 @@ def build_auto_perfreports_parser() -> argparse.ArgumentParser:
 def build_export_perfdata_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--file", type=str, help="Output filename")
+    parser.add_argument("--name", type=str, help="Custom DataFrame variable name")
     parser.add_argument(
         "--level",
         default="process",
@@ -66,6 +67,7 @@ def build_export_perfdata_parser() -> argparse.ArgumentParser:
 def build_export_cell_history_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--file", type=str, help="Output filename")
+    parser.add_argument("--name", type=str, help="Custom DataFrame variable name")
     return parser
 
 def build_import_perfdata_parser() -> argparse.ArgumentParser:

--- a/jumper_extension/core/service.py
+++ b/jumper_extension/core/service.py
@@ -244,13 +244,15 @@ class PerfmonitorService:
     def export_perfdata(
         self,
         file: Optional[str] = None,
-        level: Optional[str] = None
+        level: Optional[str] = None,
+        name: Optional[str] = None
     ) -> Optional[Dict[str, pd.DataFrame]]:
         """Export performance data to file or return as DataFrame.
 
         Args:
             file: File path for export or None to return DataFrame
             level: Monitoring level or None for default
+            name: Custom variable name for returned DataFrame
 
         Returns:
             Dictionary with DataFrame if file is None, empty dict otherwise
@@ -270,7 +272,7 @@ class PerfmonitorService:
             df = self.monitor.data.view(
                 level=level, cell_history=self.cell_history
             )
-            var_name = self.settings.export_vars.perfdata
+            var_name = name or self.settings.export_vars.perfdata
             logger.info(
                 EXTENSION_INFO_MESSAGES[
                     ExtensionInfoCode.PERFORMANCE_DATA_AVAILABLE
@@ -299,12 +301,14 @@ class PerfmonitorService:
 
     def export_cell_history(
         self,
-        file: Optional[str] = None
+        file: Optional[str] = None,
+        name: Optional[str] = None
     ) -> Optional[Dict[str, pd.DataFrame]]:
         """Export cell history to file or return as DataFrame.
 
         Args:
             file: File path for export or None to return DataFrame
+            name: Custom variable name for returned DataFrame
 
         Returns:
             Dictionary with DataFrame if file is None, empty dict otherwise
@@ -314,7 +318,7 @@ class PerfmonitorService:
             return {}
         else:
             df = self.cell_history.view()
-            var_name = self.settings.export_vars.cell_history
+            var_name = name or self.settings.export_vars.cell_history
             logger.info(
                 f"[JUmPER]: Cell history data available as '{var_name}'"
             )
@@ -501,7 +505,8 @@ class PerfmonitorMagicAdapter:
         args = parse_arguments(self.parsers.export_perfdata, line)
         return self.service.export_perfdata(
             file=args.file if args else None,
-            level=args.level if args else None
+            level=args.level if args else None,
+            name=args.name if args else None
         )
 
     def perfmonitor_load_perfdata(self, line: str) -> Optional[Dict[str, pd.DataFrame]]:
@@ -515,7 +520,8 @@ class PerfmonitorMagicAdapter:
         """Export cell history or push as DataFrame."""
         args = parse_arguments(self.parsers.export_cell_history, line)
         return self.service.export_cell_history(
-            file=args.file if args else None
+            file=args.file if args else None,
+            name=args.name if args else None
         )
 
     def perfmonitor_load_cell_history(self, line: str) -> Optional[Dict[str, pd.DataFrame]]:
@@ -542,10 +548,10 @@ class PerfmonitorMagicAdapter:
             "perfmonitor_plot -- interactive plot with widgets for data exploration",
             "perfmonitor_enable_perfreports [--level LEVEL] [--interval INTERVAL] [--text] -- enable auto-reports",
             "perfmonitor_disable_perfreports -- disable auto-reports",
-            "perfmonitor_export_perfdata [--file FILE] [--level LEVEL] -- export CSV;"
-            " without --file pushes DataFrame 'perfdata_df'",
-            "perfmonitor_export_cell_history [--file FILE] -- export history to JSON/CSV;"
-            " without --file pushes DataFrame 'cell_history_df'",
+            "perfmonitor_export_perfdata [--file FILE] [--level LEVEL] [--name NAME] -- export CSV;"
+            " without --file pushes DataFrame (default 'perfdata_df')",
+            "perfmonitor_export_cell_history [--file FILE] [--name NAME] -- export history to JSON/CSV;"
+            " without --file pushes DataFrame (default 'cell_history_df')",
             "export_session [target|target.zip] -- export full session",
             "import_session <dir-or-zip> -- import full session for offline analysis",
         ]

--- a/jumper_extension/ipython/magics.py
+++ b/jumper_extension/ipython/magics.py
@@ -73,8 +73,8 @@ class PerfmonitorMagics(Magics):
         Usage:
           %perfmonitor_export_perfdata --file <path> [--level LEVEL]
             # export to file
-          %perfmonitor_export_perfdata [--level LEVEL]
-            # push DataFrame
+          %perfmonitor_export_perfdata [--name NAME] [--level LEVEL]
+            # push DataFrame (optionally specify variable name)
         """
         perfdata = self.magic_adapter.perfmonitor_export_perfdata(line)
         self.shell.push(perfdata)
@@ -85,7 +85,7 @@ class PerfmonitorMagics(Magics):
 
         Usage:
           %perfmonitor_export_cell_history --file <path>  # export to file
-          %perfmonitor_export_cell_history                # push DataFrame
+          %perfmonitor_export_cell_history [--name NAME]  # push DataFrame
         """
         cell_history_data = self.magic_adapter.perfmonitor_export_cell_history(line)
         self.shell.push(cell_history_data)

--- a/tests/test_magic_commands.py
+++ b/tests/test_magic_commands.py
@@ -196,12 +196,32 @@ def test_export_and_help(ipython, mock_cpu_only):
 
     # Test exports with monitor
     magics.perfmonitor_start("")
+    df = pd.DataFrame({"time": [1.0]})
+    with patch.object(
+        magics.magic_adapter.service.monitor.data,
+        "view",
+        return_value=df,
+    ):
+        magics.perfmonitor_export_perfdata("--name custom_perf")
+        assert "custom_perf" in ipython.user_ns
+        assert ipython.user_ns["custom_perf"].equals(df)
+    ipython.user_ns.pop("custom_perf", None)
     with patch.object(magics.magic_adapter.service.monitor.data, "export"):
         magics.perfmonitor_export_perfdata("")
         magics.perfmonitor_export_perfdata("--file custom.csv")
     magics.perfmonitor_stop("")
 
     # Test cell history export
+    ch_df = pd.DataFrame({"cell_index": [0]})
+    with patch.object(
+        magics.magic_adapter.service.cell_history,
+        "view",
+        return_value=ch_df,
+    ):
+        magics.perfmonitor_export_cell_history("--name custom_history")
+        assert "custom_history" in ipython.user_ns
+        assert ipython.user_ns["custom_history"].equals(ch_df)
+    ipython.user_ns.pop("custom_history", None)
     with patch.object(magics.magic_adapter.service.cell_history, "export"):
         magics.perfmonitor_export_cell_history("")
         magics.perfmonitor_export_cell_history("--file custom.json")


### PR DESCRIPTION
- Added optional --name flag to %perfmonitor_export_perfdata and %perfmonitor_export_cell_history
- Added test coverage to confirm custom names are pushed into the IPython namespace (tests/test_magic_commands.py)